### PR TITLE
update prost-build and tonic-build version 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ tonic = ["tonic-build"]
 prost = ["prost-build"]
 
 [dependencies]
-prost-build = { version = "0.12.4", optional = true }
-tonic-build = { version = "0.11.0", optional = true }
+prost-build = { version = "0.13.2", optional = true }
+tonic-build = { version = "0.12.2", optional = true }
 
 [dev-dependencies]
 insta = "1.34.0"

--- a/cliff.toml
+++ b/cliff.toml
@@ -46,7 +46,7 @@ footer = """
 trim = true
 # postprocessors
 postprocessors = [
-  { pattern = '\$REPO', replace = "https://github.com/tyrchen/proto-builder-trait" }, # replace repository URL
+    { pattern = '\$REPO', replace = "https://github.com/m104ngc4594/proto-builder-trait" }, # replace repository URL
 ]
 
 [git]
@@ -58,24 +58,24 @@ filter_unconventional = false
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
-  # { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/orhun/git-cliff/issues/${2}))"}, # replace issue numbers
+    # { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/orhun/git-cliff/issues/${2}))"}, # replace issue numbers
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-  { message = "\\[skip", skip = true },
-  { message = "\\p{Han}", skip = true },
-  { message = "^feat", group = "Features" },
-  { message = "^fix", group = "Bug Fixes" },
-  { message = "^doc", group = "Documentation" },
-  { message = "^perf", group = "Performance" },
-  { message = "^refactor", group = "Refactoring" },
-  { message = "^style", group = "Style" },
-  { message = "^revert", group = "Revert" },
-  { message = "^test", group = "Tests" },
-  { message = "^chore\\(version\\):", skip = true },
-  { message = "^chore", group = "Miscellaneous Chores" },
-  { message = ".*", group = "Other" },
-  { body = ".*security", group = "Security" },
+    { message = "\\[skip", skip = true },
+    { message = "\\p{Han}", skip = true },
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Style" },
+    { message = "^revert", group = "Revert" },
+    { message = "^test", group = "Tests" },
+    { message = "^chore\\(version\\):", skip = true },
+    { message = "^chore", group = "Miscellaneous Chores" },
+    { message = ".*", group = "Other" },
+    { body = ".*security", group = "Security" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false


### PR DESCRIPTION
This avoids compilation errors, as there is no corresponding with_serde method.